### PR TITLE
Fix sigma_h calculation in read_ATL11

### DIFF
--- a/intro_to_ATL11.ipynb
+++ b/intro_to_ATL11.ipynb
@@ -435,7 +435,7 @@
     "    for col in range(h_corr.shape[1]):\n",
     "        h_corr[quality==6]=np.NaN\n",
     "    # return the values\n",
-    "    return longitude, latitude, h_corr, np.sqrt(h_corr**2+h_corr_sigma**2)"
+    "    return longitude, latitude, h_corr, np.sqrt(h_corr_sigma**2+h_corr_sigma_s**2)"
    ]
   },
   {


### PR DESCRIPTION
Just fixing a small error in the intro jupyter notebook's `read_ATL11` function. Shouldn't affect the subsequent plots though. Great work by the way :smile: