### PR TITLE
correcting group copy

### DIFF
--- a/h5util.py
+++ b/h5util.py
@@ -94,7 +94,7 @@ def duplicate_group(f_in, f_out, ingroup):
   if ingroup not in f_in:
       print("[duplicate_group] Error, requested input group not present")
       return
-# Remove outgroup if it already exists and option to retain is not provided
+# Remove outgroup if it already exists
   if ingroup in f_out:
       del f_out[ingroup]
   f_out.require_group(ingroup)

--- a/h5util.py
+++ b/h5util.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 
 from h5py import h5a, h5t, h5s
+import h5py
 import numpy as np
 
 
@@ -78,3 +79,32 @@ def create_attribute(_id, _name, _dims, _value):
   return _aid
 # enddef -----------------------------------------------------------------------
 
+def duplicate_group(f_in, f_out, ingroup):
+  """
+  Duplicates group from one h5 object to another
+ 
+  f_in should the result of something like f = h5py.File(infile,'r')
+
+  f_out should the result of something like f = h5py.File(infile,'r+')
+ 
+  ingroup should be a string.
+ 
+  """
+# Check that ingroup exists in f_in
+  if ingroup not in f_in:
+      print("[duplicate_group] Error, requested input group not present")
+      return
+# Remove outgroup if it already exists and option to retain is not provided
+  if ingroup in f_out:
+      del f_out[ingroup]
+  f_out.require_group(ingroup)
+  for dset in f_in[ingroup].values():
+      f_out[ingroup].create_dataset_like(dset.name, dset, data=np.array(dset))
+      for att in dset.attrs:
+        if att == 'DIMENSION_SCALE': continue
+        if att == 'CLASS': continue
+        if att == 'NAME': continue
+        if att == 'DIMENSION_LIST': continue
+        if att == 'REFERENCE_LIST': continue
+        f_out[ingroup][dset.name].attrs[att] = dset.attrs[att]
+  return

--- a/write_METADATA.py
+++ b/write_METADATA.py
@@ -12,7 +12,7 @@ import numpy as np
 import sys
 from datetime import datetime
 import ATL11
-from ATL11.h5util import create_attribute
+from ATL11.h5util import create_attribute, duplicate_group
 from ATL11.version import version
 
 def write_METADATA(outfile,infiles):
@@ -167,7 +167,6 @@ def filemeta(outfile,infiles):
                              val = f.attrs[key]
                              g.attrs[key]=val
                            else:
-#                             val = f.attrs[key].astype('U13')
                              val = f.attrs[key].decode()
                              create_attribute(g.id, key, [], val)
                     del g['METADATA/Extent']
@@ -175,19 +174,7 @@ def filemeta(outfile,infiles):
 
 #
 # Read the datasets from orbit_info
-#
-# BPJ: The orbit info add on doesn't work with "processed_*" files
-### Why segfault?                    f.copy('orbit_info',g)
-# NOTE: Comment out the 1 following line if using subset files from NSIDC!
-                    gf = f.copy('orbit_info',g)
-#                    for key, keyval in orbit_info.items():
-#                        dsname='/orbit_info/'+key
-#                        if dsname in f:
-#                           f.copy(dsname,gf)
-#                           if f[dsname].dtype.kind == 'S':
-#                               orbit_info[key] = (f[dsname][0].decode()).strip()
-#                           else:
-#                               orbit_info[key] = f[dsname][0]
+                    duplicate_group(f, g, 'orbit_info')
 
                 m.close()
                 f.close()
@@ -206,8 +193,6 @@ def filemeta(outfile,infiles):
                        end_delta_time = f['ancillary_data/end_delta_time'][0]
                        val = float(end_delta_time) - float(start_delta_time)
                        g.attrs[key] = val
-#                           create_attribute(g.id, key, [], np.string(val))
-#                gf = g['METADATA']['Lineage']['Control'].attrs['control'].decode()
                 g['ancillary_data/data_end_utc'][...] = f['ancillary_data/data_end_utc']
                 g['ancillary_data/end_cycle'][...] = f['ancillary_data/end_cycle']
                 g['ancillary_data/end_delta_time'][...] = f['ancillary_data/end_delta_time']


### PR DESCRIPTION
h5py cannot copy groups with dimension_scales present without destroying links, leading to broken datasets. Utility developed to handle group copy.