### PR TITLE
cleaning up print statements

### DIFF
--- a/write_METADATA.py
+++ b/write_METADATA.py
@@ -187,9 +187,6 @@ def filemeta(outfile,infiles):
               if os.path.isfile(infile):
                 f = h5py.File(infile,'r')
                 for oi_dset in g['orbit_info'].values():
-                   print('maxshape',oi_dset.name)
-                   print(oi_dset.shape)
-                   print(oi_dset.shape[0])
                    oi_dset.resize( (oi_dset.shape[0]+1,) )
                    oi_dset[-1] = f[oi_dset.name][0]
                 f.close()


### PR DESCRIPTION
orbit_info now to include all cycle data. METADATA/Extent also now covers the temporal extent of cycles correctly.